### PR TITLE
Fix Docker build and correct Python script errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim
 # ── ① 共通ツール ＋ Node.js ───────────────────────────────────────
 RUN apt-get update && apt-get install -y \
     curl gnupg build-essential git \
-    python3-dev python3-pip python3.11-dev iputils-ping
+    python3-dev python3-pip iputils-ping
 
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs
@@ -36,6 +36,7 @@ RUN npm install \
         mineflayer-web-inventory \
         mineflayer-tool \
         mineflayer-pvp \
-        prismarine-viewer
+        prismarine-viewer \
+        canvas
 
 WORKDIR /app

--- a/discovery/autoggen.py
+++ b/discovery/autoggen.py
@@ -7,16 +7,16 @@ from openai import AsyncOpenAI
 from dotenv import load_dotenv
 from typing import List
 
-from autogen_agentchat.agents import AssistantAgent
-from autogen_agentchat.conditions import ExternalTermination, TextMentionTermination
-from autogen_agentchat.teams import SelectorGroupChat
-from autogen_agentchat.ui import Console
-from autogen_ext.models.openai import OpenAIChatCompletionClient
-from autogen_core.model_context import UnboundedChatCompletionContext
-from autogen_core.tools import FunctionTool
-from autogen_core.models import ModelFamily
-from autogen_core.models import AssistantMessage, LLMMessage, ModelFamily
-from autogen_ext.models.ollama import OllamaChatCompletionClient
+from autogen.agentchat.agents import AssistantAgent
+from autogen.agentchat.conditions import ExternalTermination, TextMentionTermination
+from autogen.agentchat.teams import SelectorGroupChat
+from autogen.agentchat.ui import Console
+from autogen.ext.models.openai import OpenAIChatCompletionClient
+from autogen.core.model_context import UnboundedChatCompletionContext
+from autogen.core.tool import FunctionTool
+from autogen.core.model import ModelFamily
+from autogen.core.message import AssistantMessage, LLMMessage
+from autogen.ext.models.ollama import OllamaChatCompletionClient
 
 
 class ReasoningModelContext(UnboundedChatCompletionContext):

--- a/discovery/fastapi_app.py
+++ b/discovery/fastapi_app.py
@@ -5,8 +5,9 @@ from typing import List, Optional, Dict, Any
 import uvicorn
 import asyncio
 from discovery import Discovery
+from skill.skills import Skills
 from contextlib import asynccontextmanager
-import math # math.fabs を使うためにインポート
+import math
 from javascript import require # Vec3 を使う可能性のため (skills.pyの依存関係)
 import inspect # メソッドとdocstring取得のため
 import io # 標準出力/エラー出力キャプチャのため
@@ -27,8 +28,8 @@ current_goal: Optional[str] = None # ★ 追加: 現在のゴールを格納す�
 async def lifespan(app: FastAPI):
     # アプリケーション起動時の処理
     global skills
-    discovery.bot_join()
-    skills = discovery.create_skills()
+    await discovery.check_server_and_join()
+    skills = discovery.skills
     # サーバー接続確認（非同期で実行）
     asyncio.create_task(check_server_connection())
     


### PR DESCRIPTION
This commit resolves a Docker build failure and corrects several errors in the Python application scripts.

The `Dockerfile` is updated to:
- Remove the `python3.11-dev` package, which is not available in the base image and was causing the build to fail.
- Add the `canvas` npm package, which is a required dependency for `prismarine-viewer`.

The Python scripts in the `discovery` directory have been updated to fix the following errors:
- `discovery/autoggen.py`: Corrected the import paths for the `autogen` library.
- `discovery/fastapi_app.py`: Fixed the application startup logic in the `lifespan` function to correctly initialize the bot and skills.
- `discovery/llm.py`: Modified the `LLMClient` to accept the `discovery` object, enabling it to correctly call skill-related methods.