### PR TITLE
Fix ModuleNotFoundError for skill module

### DIFF
--- a/discovery/discovery.py
+++ b/discovery/discovery.py
@@ -2,7 +2,7 @@ from javascript import require, On, Once, AsyncTask, once, off
 from dotenv import load_dotenv
 import os
 import asyncio
-from skill.skills import Skills
+from .skill.skills import Skills
 import webbrowser
 import sys
 import math

--- a/discovery/fastapi_app.py
+++ b/discovery/fastapi_app.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Dict, Any
 import uvicorn
 import asyncio
 from discovery import Discovery
-from skill.skills import Skills
+from discovery.skill.skills import Skills
 from contextlib import asynccontextmanager
 import math
 from javascript import require # Vec3 を使う可能性のため (skills.pyの依存関係)


### PR DESCRIPTION
This commit resolves a `ModuleNotFoundError: No module named 'skill'` by correctly turning the `skill` directory into a Python package and updating the relevant import statements.

- An empty `__init__.py` file is added to `discovery/skill/`.
- The import in `discovery/discovery.py` is changed to a relative import: `from .skill.skills import Skills`.
- The import in `discovery/fastapi_app.py` is changed to a package-absolute import: `from discovery.skill.skills import Skills`.