### PR TITLE
Fix ModuleNotFoundError for autogen and skill modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # ── ③ Python パッケージ ──────────────────────────────────────────
-RUN pip install -U autogen-agentchat autogen-ext[openai] autogen-agentchat[lmm]~=0.2 autogen-agentchat[gemini]~=0.2
+RUN pip install -U autogen-agentchat autogen-ext[openai] autogen-agentchat[lmm]~=0.2 autogen-agentchat[gemini]~=0.2 autogen-core
 
 WORKDIR /app
 COPY requirements.txt README.md ./

--- a/discovery/autoggen.py
+++ b/discovery/autoggen.py
@@ -7,16 +7,16 @@ from openai import AsyncOpenAI
 from dotenv import load_dotenv
 from typing import List
 
-from autogen.agentchat.agents import AssistantAgent
-from autogen.agentchat.conditions import ExternalTermination, TextMentionTermination
-from autogen.agentchat.teams import SelectorGroupChat
-from autogen.agentchat.ui import Console
-from autogen.ext.models.openai import OpenAIChatCompletionClient
-from autogen.core.model_context import UnboundedChatCompletionContext
-from autogen.core.tool import FunctionTool
-from autogen.core.model import ModelFamily
-from autogen.core.message import AssistantMessage, LLMMessage
-from autogen.ext.models.ollama import OllamaChatCompletionClient
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.conditions import ExternalTermination, TextMentionTermination
+from autogen_agentchat.teams import SelectorGroupChat
+from autogen_agentchat.ui import Console
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+from autogen_core.model_context import UnboundedChatCompletionContext
+from autogen_core.tools import FunctionTool
+from autogen_core.models import ModelFamily
+from autogen_core.models import AssistantMessage, LLMMessage, ModelFamily
+from autogen_ext.models.ollama import OllamaChatCompletionClient
 
 
 class ReasoningModelContext(UnboundedChatCompletionContext):


### PR DESCRIPTION
This commit resolves a `ModuleNotFoundError` for the `autogen` package by reverting incorrect import path changes in `discovery/autoggen.py` and adding `autogen-core` to the `pip install` command in the `Dockerfile`.

This commit also includes the previous fix for the `skill` module import error, which involved adding an `__init__.py` to `discovery/skill/` and correcting the import statements in `discovery/discovery.py` and `discovery/fastapi_app.py`.

Finally, this commit retains the fixes for the original Docker build error and other latent runtime errors discovered during the debugging process.