### PR TITLE
Fix ModuleNotFoundError for ollama package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv
 google-generativeai
 openai
 langchain
+ollama


### PR DESCRIPTION
This commit resolves a `ModuleNotFoundError: No module named 'ollama'` by adding the `ollama` package to `requirements.txt`. This is a dependency of the `autogen-ext` library and was causing a runtime error.

This commit builds upon the previous fixes for the Docker build, the `skill` module import, and the `autogen` module import.