### PR TITLE
Fix relative imports and add missing dependencies

### DIFF
--- a/discovery/main.py
+++ b/discovery/main.py
@@ -1,5 +1,5 @@
-from discovery import Discovery
-from autoggen import Auto_gen
+from .discovery import Discovery
+from .autoggen import Auto_gen
 import asyncio
 import traceback # トレースバック取得のため
 


### PR DESCRIPTION
This commit resolves a series of `ModuleNotFoundError` exceptions and a Docker build failure.

- The `python3.11-dev` package is removed from the `Dockerfile` to fix the build.
- An `__init__.py` file is added to `discovery/skill/` to make it a package.
- Imports within the `discovery` package are corrected to be relative (e.g., `from .autoggen import Auto_gen`).
- The `ollama` package is added to `requirements.txt`.
- The `autogen-core` package is added to the `pip install` command in the `Dockerfile`.
- The `canvas` npm package is added to the `npm install` command in the `Dockerfile`.