### PR TITLE
Fix Docker build, import errors, and JS environment

### DIFF
--- a/discovery/discovery.py
+++ b/discovery/discovery.py
@@ -19,6 +19,11 @@ from playwright.async_api import async_playwright
 
 class Discovery:
     def __init__(self):
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        project_root = os.path.dirname(script_dir)
+        node_modules_path = os.path.join(project_root, 'mineflayer', 'node_modules')
+        os.environ['NODE_PATH'] = node_modules_path
+
         load_dotenv()
         self.load_env()
         self.mineflayer = require("mineflayer")
@@ -40,8 +45,6 @@ class Discovery:
         self.prismarine_viewer_port = os.getenv("PRISMARINE_VIEWER_PORT", 3000)
 
     def load_plugins(self):
-        # Node.jsのモジュールパスを設定（mineflayerディレクトリのnode_modulesを参照）
-        os.environ['NODE_PATH'] = "/workspaces/Voyager/mineflayer/node_modules"
         # pathfinder
         self.pathfinder = require("mineflayer-pathfinder")
         self.web_inventory = require("mineflayer-web-inventory")


### PR DESCRIPTION
This commit resolves a series of build-time and run-time errors that prevented the application from starting.

- **Dockerfile:**
    - Removed `python3.11-dev` to fix the initial build failure.
    - Added `autogen-core` to the `pip install` command.
    - Added `canvas` to the `npm install` command.

- **Dependencies:**
    - Added `ollama` to `requirements.txt`.

- **Python Code:**
    - Added `discovery/skill/__init__.py` to create a valid package.
    - Corrected all intra-package imports in `discovery/main.py`, `discovery/discovery.py`, and `discovery/fastapi_app.py` to use relative or package-absolute paths.
    - Reverted incorrect changes to `autogen` import paths in `discovery/autoggen.py`.
    - Corrected the `NODE_PATH` environment variable in `discovery/discovery.py` to point to the correct `node_modules` directory and ensured it is set before `require()` is called.
    - Fixed latent bugs in `fastapi_app.py` and `llm.py` related to application startup and method calls.